### PR TITLE
Add a `data` object payload in the definition of a Seat.

### DIFF
--- a/src/__mock__/seats.js
+++ b/src/__mock__/seats.js
@@ -6,6 +6,15 @@
 export const seatsData = {
   '1': { id: 1, x: 50, y: 60, label: 'G-13' },
   '2': { id: 2, x: 150, y: 60, label: 'G-14' },
-  '3': { id: 3, x: 250, y: 60, label: 'G-15' },
+  '3': {
+    id: 3,
+    x: 250,
+    y: 60,
+    label: 'G-15',
+    data: {
+      ticket_type: 'VIP',
+      username: 'aviau'
+    },
+  },
   '4': { id: 4, x: 350, y: 60, label: 'G-16' },
 };

--- a/src/types.js
+++ b/src/types.js
@@ -9,4 +9,5 @@ export type SeatData = {
   x: number,
   y: number,
   label: string,  // what's written on the seat
+  data?: Object,  // aditionnal data associated with this seat.
 };


### PR DESCRIPTION
## based on #13 

This PR implements a solution for #19 

This PR add a `data` object inside the definition of the seat.

This object serve as a container to store meta data defined by the user of the service. This data can be used to implement some sort of business logic defined by users on top of the client.