### PR TITLE
Implement a basic Tooltip

### DIFF
--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -14,9 +14,9 @@ describe('Passing an empty state to the tooltip reducer', () => {
 
 describe('reducer handles SHOW_TOOLTIP action', () => {
   it('sets the display boolean to true', () => {
-    const action = showTooltip('some text goes here');
+    const action = showTooltip(50, 100, 'some text goes here');
     const before = initial;
-    const after = { ...before, display: true };
+    const after = { ...before, display: true, x: 50, y: 100 };
 
     expect(reducer(before, action)).toEqual(after);
   });

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -4,24 +4,15 @@ import { showTooltip, hideTooltip } from '../../src/actions/tooltip';
 
 describe('reducer handles SHOW_TOOLTIP action', () => {
   it('sets the display boolean to true', () => {
-    const action = showTooltip(50, 100, 'some text goes here');
+    const action = showTooltip('some text goes here');
     const before = initial;
     const after = reducer(before, action);
 
     expect(after.display).toEqual(true);
   });
 
-  it('sets the x and y values to the action values', () => {
-    const action = showTooltip(50, 100, 'some text goes here');
-    const before = initial;
-    const after = reducer(before, action);
-
-    expect(after.x).toEqual(50);
-    expect(after.y).toEqual(100);
-  });
-
   it('sets the text values to the action value', () => {
-    const action = showTooltip(50, 100, 'some text goes here');
+    const action = showTooltip('some text goes here');
     const before = initial;
     const after = reducer(before, action);
 

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -19,4 +19,12 @@ describe('reducer handles SHOW_TOOLTIP action', () => {
     expect(after.x).toEqual(50);
     expect(after.y).toEqual(100);
   });
+
+  it('sets the text values to the action value', () => {
+    const action = showTooltip(50, 100, 'some text goes here');
+    const before = initial;
+    const after = reducer(before, action);
+
+    expect(after.text).toEqual('some text goes here');
+  });
 });

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -2,6 +2,16 @@ import reducer, { initial } from '../../src/reducers/tooltip';
 import { showTooltip } from '../../src/actions/tooltip';
 
 
+describe('Passing an empty state to the tooltip reducer', () => {
+  it('uses a default `initial` state', () => {
+    const action = showTooltip('some text goes here');
+    const before = undefined;
+    const after = { ...before, display: true };
+
+    expect(reducer(before, action)).toEqual(after);
+  });
+});
+
 describe('reducer handles SHOW_TOOLTIP action', () => {
   it('sets the display boolean to true', () => {
     const action = showTooltip('some text goes here');

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -2,22 +2,21 @@ import reducer, { initial } from '../../src/reducers/tooltip';
 import { showTooltip } from '../../src/actions/tooltip';
 
 
-describe('Passing an empty state to the tooltip reducer', () => {
-  it('uses a default `initial` state', () => {
-    const action = showTooltip('some text goes here');
-    const before = undefined;
-    const after = { ...before, display: true };
-
-    expect(reducer(before, action)).toEqual(after);
-  });
-});
-
 describe('reducer handles SHOW_TOOLTIP action', () => {
   it('sets the display boolean to true', () => {
     const action = showTooltip(50, 100, 'some text goes here');
     const before = initial;
-    const after = { ...before, display: true, x: 50, y: 100 };
+    const after = reducer(before, action);
 
-    expect(reducer(before, action)).toEqual(after);
+    expect(after.display).toEqual(true);
+  });
+
+  it('sets the x and y values to the action values', () => {
+    const action = showTooltip(50, 100, 'some text goes here');
+    const before = initial;
+    const after = reducer(before, action);
+
+    expect(after.x).toEqual(50);
+    expect(after.y).toEqual(100);
   });
 });

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -1,0 +1,12 @@
+import reducer, { initial } from '../../src/reducers/tooltip';
+
+
+describe('reducer handles SHOW_TOOLTIP action', () => {
+  it('sets the display boolean to true', () => {
+    const action = showTooltip('some text goes here');
+    const before = initial;
+    const after = { ...before, display: true };
+
+    expect(reducer(before, action)).toEqual(after);
+  });
+});

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -1,4 +1,5 @@
 import reducer, { initial } from '../../src/reducers/tooltip';
+import { showTooltip } from '../../src/actions/tooltip';
 
 
 describe('reducer handles SHOW_TOOLTIP action', () => {

--- a/__tests__/reducers/tooltip.js
+++ b/__tests__/reducers/tooltip.js
@@ -1,5 +1,5 @@
 import reducer, { initial } from '../../src/reducers/tooltip';
-import { showTooltip } from '../../src/actions/tooltip';
+import { showTooltip, hideTooltip } from '../../src/actions/tooltip';
 
 
 describe('reducer handles SHOW_TOOLTIP action', () => {
@@ -26,5 +26,15 @@ describe('reducer handles SHOW_TOOLTIP action', () => {
     const after = reducer(before, action);
 
     expect(after.text).toEqual('some text goes here');
+  });
+});
+
+describe('reducer handles HIDE_TOOLTIP action', () => {
+  it('sets the display boolean to false', () => {
+    const action = hideTooltip();
+    const before = { ...initial, display: true };
+    const after = reducer(before, action);
+
+    expect(after.display).toEqual(false);
   });
 });

--- a/src/actions/tooltip.js
+++ b/src/actions/tooltip.js
@@ -1,0 +1,8 @@
+// @flow
+
+import type { Action } from './types';
+
+
+export function showTooltip(text: string): Action {
+  return { type: 'SHOW_TOOLTIP', text };
+}

--- a/src/actions/tooltip.js
+++ b/src/actions/tooltip.js
@@ -3,13 +3,8 @@
 import type { Action } from './types';
 
 
-export function showTooltip(x: number, y:number, text: string): Action {
-  return {
-    type: 'SHOW_TOOLTIP',
-    x,
-    y,
-    text,
-  };
+export function showTooltip(text: string): Action {
+  return { type: 'SHOW_TOOLTIP', text };
 }
 
 export function hideTooltip(): Action {

--- a/src/actions/tooltip.js
+++ b/src/actions/tooltip.js
@@ -3,6 +3,11 @@
 import type { Action } from './types';
 
 
-export function showTooltip(text: string): Action {
-  return { type: 'SHOW_TOOLTIP', text };
+export function showTooltip(x: number, y:number, text: string): Action {
+  return {
+    type: 'SHOW_TOOLTIP',
+    x,
+    y,
+    text,
+  };
 }

--- a/src/actions/tooltip.js
+++ b/src/actions/tooltip.js
@@ -11,3 +11,7 @@ export function showTooltip(x: number, y:number, text: string): Action {
     text,
   };
 }
+
+export function hideTooltip(): Action {
+  return { type: 'HIDE_TOOLTIP' };
+}

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -13,5 +13,5 @@ export type Action =
 | { type: 'ZOOM_OUT', value: number }
 
   //  Tooltip actions
-| { type: 'SHOW_TOOLTIP', text: string, x: number, y: number }
+| { type: 'SHOW_TOOLTIP', text: string }
 | { type: 'HIDE_TOOLTIP' }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -14,3 +14,4 @@ export type Action =
 
   //  Tooltip actions
 | { type: 'SHOW_TOOLTIP', text: string, x: number, y: number }
+| { type: 'HIDE_TOOLTIP' }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -11,3 +11,6 @@ export type Action =
   // Zoom actions
 | { type: 'ZOOM_IN', value: number }
 | { type: 'ZOOM_OUT', value: number }
+
+  //  Tooltip actions
+| { type: 'SHOW_TOOLTIP', text: string }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -13,4 +13,4 @@ export type Action =
 | { type: 'ZOOM_OUT', value: number }
 
   //  Tooltip actions
-| { type: 'SHOW_TOOLTIP', text: string }
+| { type: 'SHOW_TOOLTIP', text: string, x: number, y: number }

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -11,7 +11,7 @@ type Props = {
   seats: SeatsMap,
   zoom: number,
 
-  showTooltip: (x: number, y: number, text: string ) => void,
+  showTooltip: (text: string ) => void,
   hideTooltip: () => void,
 }
 
@@ -54,7 +54,7 @@ export default class Floorplan extends React.Component {
       const seat = new Seat(seatdata.x, seatdata.y);
 
       seat.onMouseEnter = () => {
-        this.props.showTooltip(100, 100, `ZergoV | ${seatdata.label}`);
+        this.props.showTooltip(`ZergoV | ${seatdata.label}`);
       }
 
       seat.onMouseLeave = () => {

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -53,13 +53,9 @@ export default class Floorplan extends React.Component {
       const seatdata = this.props.seats[id];
       const seat = new Seat(seatdata.x, seatdata.y);
 
-      seat.onMouseEnter = () => {
-        this.props.showTooltip(`ZergoV | ${seatdata.label}`);
-      }
-
-      seat.onMouseLeave = () => {
-        this.props.hideTooltip();
-      }
+      // events binding
+      seat.onMouseEnter = () => this.props.showTooltip(seatdata.label);
+      seat.onMouseLeave = () => this.props.hideTooltip();
 
       this.seats.push(seat);
     }

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -49,6 +49,15 @@ export default class Floorplan extends React.Component {
     for (const id in this.props.seats) {
       const seatdata = this.props.seats[id];
       const seat = new Seat(seatdata.x, seatdata.y);
+
+      seat.onMouseEnter = () => {
+        console.log(`entering seat: ${seatdata.label}`);
+      }
+
+      seat.onMouseLeave = () => {
+        console.log(`exiting seat: ${seatdata.label}`);
+      }
+
       this.seats.push(seat);
     }
 

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -10,6 +10,9 @@ import Seat from './Seat';
 type Props = {
   seats: SeatsMap,
   zoom: number,
+
+  showTooltip: (x: number, y: number, text: string ) => void,
+  hideTooltip: () => void,
 }
 
 export default class Floorplan extends React.Component {
@@ -51,11 +54,11 @@ export default class Floorplan extends React.Component {
       const seat = new Seat(seatdata.x, seatdata.y);
 
       seat.onMouseEnter = () => {
-        console.log(`entering seat: ${seatdata.label}`);
+        this.props.showTooltip(100, 100, `ZergoV | ${seatdata.label}`);
       }
 
       seat.onMouseLeave = () => {
-        console.log(`exiting seat: ${seatdata.label}`);
+        this.props.hideTooltip();
       }
 
       this.seats.push(seat);

--- a/src/components/FloorplanUI.js
+++ b/src/components/FloorplanUI.js
@@ -72,13 +72,11 @@ export default class FloorplanUI extends React.Component {
   }
 
   renderTooltip() {
-    if(this.props.tooltip.display) {
-      return (
-        <TooltipWrap x={this.state.mouseX} y={this.state.mouseY}>
-          { this.props.tooltip.text }
-        </TooltipWrap>
-      );
-    }
+    return (
+      <TooltipWrap x={this.state.mouseX} y={this.state.mouseY}>
+        { this.props.tooltip.text }
+      </TooltipWrap>
+    );
   }
 
   render() {
@@ -88,7 +86,7 @@ export default class FloorplanUI extends React.Component {
           <ZoomButton onClick={() => this.props.zoomIn(0.5)}>+</ZoomButton>
           <ZoomButton onClick={() => this.props.zoomOut(0.5)}>-</ZoomButton>
         </ZoomButtons>
-        { this.renderTooltip() }
+        { this.props.tooltip.display ? this.renderTooltip() : null }
       </div>
     );
   }

--- a/src/components/FloorplanUI.js
+++ b/src/components/FloorplanUI.js
@@ -30,7 +30,7 @@ const ZoomButton = styled.div`
 `;
 
 const TooltipWrap = styled.div`
-  position: absolute;
+  position: fixed;
   display: flex;
   justify-content: center;
   left: ${props => props.x}px;
@@ -48,16 +48,33 @@ type Props = {
 
   zoomIn: (val: number) => void,
   zoomOut: (val: number) => void,
-}
+};
+
+type State = {
+  mouseX: number,
+  mouseY: number,
+};
 
 export default class FloorplanUI extends React.Component {
 
   props: Props;
+  state: State;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      mouseX: 0,
+      mouseY: 0,
+    };
+
+    window.onmousemove = e => this.setState({ mouseX: e.x, mouseY: e.y });
+  }
 
   renderTooltip() {
     if(this.props.tooltip.display) {
       return (
-        <TooltipWrap x={this.props.tooltip.x} y={this.props.tooltip.y}>
+        <TooltipWrap x={this.state.mouseX} y={this.state.mouseY}>
           { this.props.tooltip.text }
         </TooltipWrap>
       );

--- a/src/components/FloorplanUI.js
+++ b/src/components/FloorplanUI.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import type { Tooltip } from '../reducers/types';
+
 
 const ZoomButtons = styled.div`
   position: absolute;
@@ -27,7 +29,7 @@ const ZoomButton = styled.div`
   margin: 0 0 8px 0;
 `;
 
-const Tooltip = styled.div`
+const TooltipWrap = styled.div`
   position: absolute;
   display: flex;
   justify-content: center;
@@ -42,6 +44,8 @@ const Tooltip = styled.div`
 
 
 type Props = {
+  tooltip: Tooltip,
+
   zoomIn: (val: number) => void,
   zoomOut: (val: number) => void,
 }
@@ -50,6 +54,16 @@ export default class FloorplanUI extends React.Component {
 
   props: Props;
 
+  renderTooltip() {
+    if(this.props.tooltip.display) {
+      return (
+        <TooltipWrap x={this.props.tooltip.x} y={this.props.tooltip.y}>
+          { this.props.tooltip.text }
+        </TooltipWrap>
+      );
+    }
+  }
+
   render() {
     return (
       <div>
@@ -57,9 +71,7 @@ export default class FloorplanUI extends React.Component {
           <ZoomButton onClick={() => this.props.zoomIn(0.5)}>+</ZoomButton>
           <ZoomButton onClick={() => this.props.zoomOut(0.5)}>-</ZoomButton>
         </ZoomButtons>
-        <Tooltip x={400} y={300}>
-          {"Zergov | C-30"}
-        </Tooltip>
+        { this.renderTooltip() }
       </div>
     );
   }

--- a/src/components/FloorplanUI.js
+++ b/src/components/FloorplanUI.js
@@ -29,12 +29,19 @@ const ZoomButton = styled.div`
   margin: 0 0 8px 0;
 `;
 
+/**
+ * A minimum offset between the mouse and the tooltip.
+ * Prevent the tooltip from beeing directly under the mouse and possible capturing a click event
+ * by mistakes.
+ */
+const tooltipOffsetX = 10;
+const tooltipOffsetY = 10;
 const TooltipWrap = styled.div`
   position: fixed;
   display: flex;
   justify-content: center;
-  left: ${props => props.x}px;
-  top: ${props => props.y}px;
+  left: ${props => props.x + tooltipOffsetX }px;
+  top: ${props => props.y + tooltipOffsetY }px;
   background-color: #000000;
   color: #ffffff;
   padding: 8px;

--- a/src/components/FloorplanUI.js
+++ b/src/components/FloorplanUI.js
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 
-const Wrapper = styled.div`
+const ZoomButtons = styled.div`
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -27,6 +27,19 @@ const ZoomButton = styled.div`
   margin: 0 0 8px 0;
 `;
 
+const Tooltip = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  left: ${props => props.x}px;
+  top: ${props => props.y}px;
+  background-color: #000000;
+  color: #ffffff;
+  padding: 8px;
+  border-radius: 4px;
+  opacity: 0.8;
+`;
+
 
 type Props = {
   zoomIn: (val: number) => void,
@@ -39,10 +52,15 @@ export default class FloorplanUI extends React.Component {
 
   render() {
     return (
-      <Wrapper>
-        <ZoomButton onClick={() => this.props.zoomIn(0.5)}>+</ZoomButton>
-        <ZoomButton onClick={() => this.props.zoomOut(0.5)}>-</ZoomButton>
-      </Wrapper>
+      <div>
+        <ZoomButtons>
+          <ZoomButton onClick={() => this.props.zoomIn(0.5)}>+</ZoomButton>
+          <ZoomButton onClick={() => this.props.zoomOut(0.5)}>-</ZoomButton>
+        </ZoomButtons>
+        <Tooltip x={400} y={300}>
+          {"Zergov | C-30"}
+        </Tooltip>
+      </div>
     );
   }
 }

--- a/src/components/Seat.js
+++ b/src/components/Seat.js
@@ -13,6 +13,9 @@ export default class Seat {
 
   visible: boolean;
 
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+
   constructor(x: number, y: number) {
     this.position = new Point(x, y);
 
@@ -25,6 +28,8 @@ export default class Seat {
     });
 
     this.item.onClick = () => console.log(this.item);
+    this.item.onMouseEnter = () => this.onMouseEnter();
+    this.item.onMouseLeave = () => this.onMouseLeave();
   }
 
   get visible(): boolean {

--- a/src/containers/Floorplan.js
+++ b/src/containers/Floorplan.js
@@ -14,7 +14,7 @@ function mapStateToProps(state: Object, props: Object) {
 
 function mapDispatchToProps(dispatch: Function) {
   return {
-    showTooltip: (x: number, y:number, text: string ) => dispatch(showTooltip(x, y, text)),
+    showTooltip: (text: string ) => dispatch(showTooltip(text)),
     hideTooltip: () => dispatch(hideTooltip()),
   }
 }

--- a/src/containers/Floorplan.js
+++ b/src/containers/Floorplan.js
@@ -2,6 +2,7 @@
 import { connect } from 'react-redux';
 
 import Floorplan from '../components/Floorplan';
+import { showTooltip, hideTooltip } from '../actions/tooltip';
 
 
 function mapStateToProps(state: Object, props: Object) {
@@ -11,6 +12,14 @@ function mapStateToProps(state: Object, props: Object) {
   }
 }
 
+function mapDispatchToProps(dispatch: Function) {
+  return {
+    showTooltip: (x: number, y:number, text: string ) => dispatch(showTooltip(x, y, text)),
+    hideTooltip: () => dispatch(hideTooltip()),
+  }
+}
+
 export default connect(
   mapStateToProps,
+  mapDispatchToProps,
 )(Floorplan);

--- a/src/containers/FloorplanUI.js
+++ b/src/containers/FloorplanUI.js
@@ -4,6 +4,11 @@ import * as zoomActions from '../actions/zoom';
 
 import FloorplanUI from '../components/FloorplanUI';
 
+function mapStateToProps(state: Object, props: Object) {
+  return {
+    tooltip: state.tooltip,
+  };
+}
 
 function mapDispatchToProps(dispatch: Function) {
   return {
@@ -13,6 +18,6 @@ function mapDispatchToProps(dispatch: Function) {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(FloorplanUI);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,8 +3,10 @@ import { combineReducers } from 'redux';
 
 import seats from './seats';
 import zoom from './zoom';
+import tooltip from './tooltip';
 
 export default combineReducers({
   seats,
   zoom,
+  tooltip,
 });

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -22,6 +22,9 @@ export default function reducer(state: Tooltip = initial, action: Action): Toolt
         text: action.text,
       };
 
+    case 'HIDE_TOOLTIP':
+      return { ...state, display: false };
+
     default:
       return state;
   }

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -5,13 +5,20 @@ import type { Tooltip } from './types';
 
 export const initial: Tooltip = {
   display: false,
+  x: 0,
+  y: 0,
 }
 
 export default function reducer(state: Tooltip, action: Action): Tooltip {
   switch(action.type) {
 
     case 'SHOW_TOOLTIP':
-      return { ...state, display: true };
+      return {
+        ...state,
+        display: true,
+        x: action.x,
+        y: action.y,
+      };
 
     default:
       return state;

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -10,7 +10,7 @@ export const initial: Tooltip = {
   text: '',
 }
 
-export default function reducer(state: Tooltip, action: Action): Tooltip {
+export default function reducer(state: Tooltip = initial, action: Action): Tooltip {
   switch(action.type) {
 
     case 'SHOW_TOOLTIP':

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -7,6 +7,7 @@ export const initial: Tooltip = {
   display: false,
   x: 0,
   y: 0,
+  text: '',
 }
 
 export default function reducer(state: Tooltip, action: Action): Tooltip {
@@ -18,6 +19,7 @@ export default function reducer(state: Tooltip, action: Action): Tooltip {
         display: true,
         x: action.x,
         y: action.y,
+        text: action.text,
       };
 
     default:

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -5,8 +5,6 @@ import type { Tooltip } from './types';
 
 export const initial: Tooltip = {
   display: false,
-  x: 0,
-  y: 0,
   text: '',
 }
 
@@ -14,13 +12,7 @@ export default function reducer(state: Tooltip = initial, action: Action): Toolt
   switch(action.type) {
 
     case 'SHOW_TOOLTIP':
-      return {
-        ...state,
-        display: true,
-        x: action.x,
-        y: action.y,
-        text: action.text,
-      };
+      return { ...state, display: true, text: action.text };
 
     case 'HIDE_TOOLTIP':
       return { ...state, display: false };

--- a/src/reducers/tooltip.js
+++ b/src/reducers/tooltip.js
@@ -1,0 +1,19 @@
+// @flow
+import type { Action } from '../actions/types';
+import type { Tooltip } from './types';
+
+
+export const initial: Tooltip = {
+  display: false,
+}
+
+export default function reducer(state: Tooltip, action: Action): Tooltip {
+  switch(action.type) {
+
+    case 'SHOW_TOOLTIP':
+      return { ...state, display: true };
+
+    default:
+      return state;
+  }
+}

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -28,4 +28,6 @@ export type Zoom = {
  */
 export type Tooltip = {
   display: boolean,
+  x: number,
+  y: number,
 };

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -28,7 +28,5 @@ export type Zoom = {
  */
 export type Tooltip = {
   display: boolean,
-  x: number,
-  y: number,
   text: string,
 };

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -30,4 +30,5 @@ export type Tooltip = {
   display: boolean,
   x: number,
   y: number,
+  text: string,
 };

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -22,3 +22,10 @@ export type Seats = {
 export type Zoom = {
   zoom: number,
 };
+
+/**
+ *  Structure of the `tooltip` store.
+ */
+export type Tooltip = {
+  display: boolean,
+};


### PR DESCRIPTION
This PR adds a basic tooltip on the floorplan. It is not yet configurable from the JS api. This will come in a future PR.

For now, it displays the label of a seat when hovering over it.

Screenshot 
![tooltip_062](https://cloud.githubusercontent.com/assets/8284973/26156220/a0170cd0-3ae3-11e7-9b78-00bf1a107692.png)

