### PR TITLE
Remove the constant update (redrawing) loop.

### DIFF
--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -68,17 +68,18 @@ export default class Floorplan extends React.Component {
     this.view.center = this.view.center.add(new Point(-delta.x, -delta.y));
 
     event.preventDefault()
+    this.update();
   }
 
   update() {
-    // hide seats that are not in the view
-    this.seats.forEach((seat) => {
-      seat.visible = seat.position.isInside(this.view.bounds);
+    requestAnimationFrame(() => {
+      // hide seats that are not in the view
+      this.seats.forEach((seat) => {
+        seat.visible = seat.position.isInside(this.view.bounds);
+      });
+
+      this.view.update();
     });
-
-    this.view.update();
-
-    requestAnimationFrame(this.update);
   }
 
   handleSelectSeat(id: string) {


### PR DESCRIPTION
This PR makes the floorplan explicitly call for an update when it's needed.

This was causing my CPU to go hard even when the floorplan wasnt moving and in general is bad since we don't want to make the floorplan work when it doesn't have to.