### PR TITLE
Implement seatColor callback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,8 +52,8 @@
         console.log(seat);
       },
       seatColor: (seat) => {
-        // odd seats are blue, even seats are red.
-        var lastdigit = parseInt(seat.label.slice(-1));
+        // odd rows are blue, even rows are red.
+        var lastdigit = seat.label.charCodeAt(0);
         return lastdigit % 2 === 0 ? 'blue' : 'red';
       }
     });

--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,11 @@
       onSelectSeat: (seat) => {
         console.log(seat);
       },
+      seatColor: (seat) => {
+        // odd seats are blue, even seats are red.
+        var lastdigit = parseInt(seat.label.slice(-1));
+        return lastdigit % 2 === 0 ? 'blue' : 'red';
+      }
     });
 
     floorplan.init();

--- a/src/client.js
+++ b/src/client.js
@@ -51,6 +51,7 @@ export class FloorplanClient {
         <Wrapper>
             <Floorplan
               onSelectSeat={this.config.onSelectSeat}
+              seatColor={this.config.seatColor || (() => null)}
             />
             <FloorplanUI />
         </Wrapper>

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -90,13 +90,19 @@ export default class Floorplan extends React.Component {
 
   update() {
     requestAnimationFrame(() => {
-      // hide seats that are not in the view
+
+      // Draw each seats based on the dynamic properties of the configuration provided
+      // by the user.
       this.seats.forEach((seat) => {
+
+        // generate the seatData used for callbacks
         const seatData = toSeatData(this.props.seats[seat.id]);
+
         seat.visible = seat.position.isInside(this.view.bounds);
         seat.color = this.props.seatColor(seatData);
       });
 
+      // redraw the whole floorplan
       this.view.update();
     });
   }

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -15,6 +15,7 @@ type Props = {
 
   // JS api callback
   onSelectSeat: (seat: SeatData) => void,
+  seatColor: (seat: SeatData) => string,
 
   showTooltip: (text: string ) => void,
   hideTooltip: () => void,
@@ -56,7 +57,7 @@ export default class Floorplan extends React.Component {
     this.seats = [];
     for (const id in this.props.seats) {
       const seatdata = this.props.seats[id];
-      const seat = new Seat(seatdata.x, seatdata.y);
+      const seat = new Seat(id, seatdata.x, seatdata.y);
 
       // events binding
       seat.onMouseEnter = () => this.props.showTooltip(seatdata.label);
@@ -91,7 +92,9 @@ export default class Floorplan extends React.Component {
     requestAnimationFrame(() => {
       // hide seats that are not in the view
       this.seats.forEach((seat) => {
+        const seatData = toSeatData(this.props.seats[seat.id]);
         seat.visible = seat.position.isInside(this.view.bounds);
+        seat.color = this.props.seatColor(seatData);
       });
 
       this.view.update();

--- a/src/components/Seat.js
+++ b/src/components/Seat.js
@@ -1,8 +1,22 @@
 // @flow
-import {Point, Shape, Group, PointText} from 'paper';
-
+import { Point, Shape, Group, PointText } from 'paper';
 import { FLAT_COLORS } from '../colors';
 
+// Define the visual definition of a `Seat` and clone
+// this definition anytime a new Seat is needed.
+let seatDefinition;
+function createSeat() {
+  if (!seatDefinition) {
+    seatDefinition = Shape.Circle({
+      position: new Point(0, 0),
+      radius: 8,
+      strokeColor: 'black',
+      fillColor: FLAT_COLORS.POMEGRANATE,
+    })
+  }
+
+  return seatDefinition.clone();
+}
 
 export default class Seat {
 
@@ -24,12 +38,8 @@ export default class Seat {
     this.id = id;
     this.position = new Point(x, y);
 
-    const radius = 9;
-    this.item = Shape.Circle({
-      position: this.position,
-      radius,
-      strokeColor: 'black',
-    });
+    this.item = createSeat();
+    this.item.position = this.position;
 
     this.item.onMouseEnter = () => this.onMouseEnter();
     this.item.onMouseLeave = () => this.onMouseLeave();

--- a/src/components/Seat.js
+++ b/src/components/Seat.js
@@ -2,21 +2,6 @@
 import { Point, Shape, Group, PointText } from 'paper';
 import { FLAT_COLORS } from '../colors';
 
-// Define the visual definition of a `Seat` and clone
-// this definition anytime a new Seat is needed.
-let seatDefinition;
-function createSeat() {
-  if (!seatDefinition) {
-    seatDefinition = Shape.Circle({
-      position: new Point(0, 0),
-      radius: 8,
-      strokeColor: 'black',
-      fillColor: FLAT_COLORS.POMEGRANATE,
-    })
-  }
-
-  return seatDefinition.clone();
-}
 
 export default class Seat {
 
@@ -38,8 +23,12 @@ export default class Seat {
     this.id = id;
     this.position = new Point(x, y);
 
-    this.item = createSeat();
-    this.item.position = this.position;
+    this.item = Shape.Circle({
+      position: this.position,
+      radius: 8,
+      strokeColor: 'black',
+      fillColor: FLAT_COLORS.POMEGRANATE,
+    });
 
     this.item.onMouseEnter = () => this.onMouseEnter();
     this.item.onMouseLeave = () => this.onMouseLeave();

--- a/src/components/Seat.js
+++ b/src/components/Seat.js
@@ -6,32 +6,42 @@ import { FLAT_COLORS } from '../colors';
 
 export default class Seat {
 
+  id: string;
   item: Group;
   position: Point;
   shape: Shape;
   text: PointText;
 
   visible: boolean;
+  color: string;
 
   onMouseEnter: () => void;
   onMouseLeave: () => void;
   onSelect: () => void;
 
-  constructor(x: number, y: number) {
+  constructor(id: string, x: number, y: number) {
 
+    this.id = id;
     this.position = new Point(x, y);
 
     const radius = 9;
     this.item = Shape.Circle({
       position: this.position,
       radius,
-      fillColor: FLAT_COLORS.POMEGRANATE,
       strokeColor: 'black',
     });
 
     this.item.onMouseEnter = () => this.onMouseEnter();
     this.item.onMouseLeave = () => this.onMouseLeave();
     this.item.onClick = () => this.onSelect();
+  }
+
+  get color(): string {
+    return this.item.fillColor;
+  }
+
+  set color(val: ?string) {
+    this.item.fillColor = val || FLAT_COLORS.POMEGRANATE;
   }
 
   get visible(): boolean {

--- a/src/types.js
+++ b/src/types.js
@@ -20,6 +20,9 @@ export type FloorplanConfig = {
   div: string,
 
   // Fired when the user selects a seat.
-  onSelectSeat: (seat: SeatData) => void;
+  onSelectSeat: (seat: SeatData) => void,
+
+  // callback defining the color a seat should have
+  seatColor: (seat: SeatData) => ?string,
 };
 


### PR DESCRIPTION
This PR adds the `seatColor` callback in the Javascript API.

This callback let the user define what the color of a specific seat should be.

Usage example:
```js
    const floorplan = new floorplanets.Floorplan({
      div: 'root',
      
      // Make the seat color blue if it's a vip seat.
      seatColor: (seat) => {
        return seat.data.VIP ? 'blue' : 'red';
      },

    });
```