### PR TITLE
backend: set IndexHandler to private

### DIFF
--- a/backend/api/handlers/lanets/handlers.go
+++ b/backend/api/handlers/lanets/handlers.go
@@ -6,6 +6,6 @@ import (
 	"net/http"
 )
 
-func IndexHandler(w http.ResponseWriter, r *http.Request) {
+func indexHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, lanetslogo.Logo)
 }

--- a/backend/api/handlers/lanets/router.go
+++ b/backend/api/handlers/lanets/router.go
@@ -5,5 +5,5 @@ import (
 )
 
 func RegisterRoutes(r *mux.Router) {
-	r.Path("/").HandlerFunc(IndexHandler)
+	r.Path("/").HandlerFunc(indexHandler)
 }


### PR DESCRIPTION
There is no reason for handlers to be public. Set it to private.