### PR TITLE
Remove lag when dragging the floorplan around.

### DIFF
--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -136,10 +136,8 @@ export default class Floorplan extends React.Component {
    */
   updateSeats() {
     this.seats.forEach((seat) => {
-      // generate the seatData used for callbacks
       const seatData = toSeatData(this.props.seats[seat.id]);
 
-      // seat.visible = seat.position.isInside(this.view.bounds);
       seat.color = this.props.seatColor(seatData);
     });
   }

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -111,7 +111,6 @@ export default class Floorplan extends React.Component {
 
   update() {
     if (this.shouldRaster) {
-      // TODO: Change isEmpty call to a call that check if the representation of the seats has changed
       if(this.rasterLayer.isEmpty())
         this.rasterLayer.addChild(this.seatsLayer.rasterize());
 

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -122,7 +122,7 @@ export default class Floorplan extends React.Component {
       this.rasterLayer.visible = false;
       this.seatsLayer.visible = true;
 
-      this.drawSeats();
+      this.updateSeats();
     }
 
     // reset the raster flag and redraw the floorplan.
@@ -131,10 +131,10 @@ export default class Floorplan extends React.Component {
   }
 
   /**
-   * Draw each seats based on the dynamic properties of the configuration provided
+   * Update each seats based on the callback properties of the configuration provided
    * by the user.
    */
-  drawSeats() {
+  updateSeats() {
     this.seats.forEach((seat) => {
       // generate the seatData used for callbacks
       const seatData = toSeatData(this.props.seats[seat.id]);


### PR DESCRIPTION
This PR is sexy. It removes the lag produced when dragging the floorplan around.

The implementation is simple. When the user starts dragging the floorplan, a [Raster](http://paperjs.org/reference/raster/) of the current floorplan is created on a separate [layer](http://paperjs.org/reference/layer/). During the dragging events, the update loop will simply render the layer containing the Raster image instead of the layer containing every single seats. Finally, when the drag is over, the Raster layer is hidden and the Seats layer is showned back to the user.

This improves the performance during the mouse drag by a HUGE amount. I seriously recomend that you check the difference by testing Master and then this branch right after. 
