### PR TITLE
Implement seatTooltip callback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,9 @@
         // odd rows are blue, even rows are red.
         var lastdigit = seat.label.charCodeAt(0);
         return lastdigit % 2 === 0 ? 'blue' : 'red';
+      },
+      seatTooltip: (seat) => {
+        return 'seat: ' + seat.label ;
       }
     });
 

--- a/src/client.js
+++ b/src/client.js
@@ -52,6 +52,7 @@ export class FloorplanClient {
             <Floorplan
               onSelectSeat={this.config.onSelectSeat}
               seatColor={this.config.seatColor || (() => null)}
+              seatTooltip={this.config.seatTooltip || (() => null)}
             />
             <FloorplanUI />
         </Wrapper>

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -15,7 +15,8 @@ type Props = {
 
   // JS api callback
   onSelectSeat: (seat: SeatData) => void,
-  seatColor: (seat: SeatData) => string,
+  seatColor: (seat: SeatData) => ?string,
+  seatTooltip: (seat: SeatData) => ?string,
 
   showTooltip: (text: string ) => void,
   hideTooltip: () => void,
@@ -65,7 +66,11 @@ export default class Floorplan extends React.Component {
       const seat = new Seat(id, seatstate.x, seatstate.y);
 
       // events binding
-      seat.onMouseEnter = () => this.props.showTooltip(seatstate.label);
+      seat.onMouseEnter = () => {
+        const tooltipText = this.props.seatTooltip(toSeatData(seatstate));
+        this.props.showTooltip(tooltipText || seatstate.label);
+      };
+
       seat.onMouseLeave = () => this.props.hideTooltip();
       seat.onSelect = () => this.props.onSelectSeat(toSeatData(seatstate));
 
@@ -76,6 +81,7 @@ export default class Floorplan extends React.Component {
   }
 
   /**
+   *
    * Called when the stores the floorplan is subscribed to is updated.
    */
   componentDidUpdate() {

--- a/src/types.js
+++ b/src/types.js
@@ -24,5 +24,8 @@ export type FloorplanConfig = {
 
   // callback defining the color a seat should have
   seatColor: (seat: SeatData) => ?string,
+
+  // callback defining the text to render in the tooltip of a seat
+  seatTooltip: (seat: SeatData) => ?string,
 };
 


### PR DESCRIPTION
closes #27 
This PR adds the seatTooltip callback to the JS API.

This callback lets a user define what should be written in the tooltip when hovering a seat.

Usage example:
```js
const floorplan = new floorplanets.Floorplan({
      div: 'root',
      
      // seat parameter contains informations about the hovered seat.
      seatTooltip: (seat) => {
        return seat.label + "(" + seat.data.ticket_type + ")";
      }
});


```