### PR TITLE
Abstract the viewport logic from Floorplan component into its own Class.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
       seatColor: (seat) => {
         // odd rows are blue, even rows are red.
         var lastdigit = seat.label.charCodeAt(0);
-        return lastdigit % 2 === 0 ? 'blue' : 'red';
+        return lastdigit % 2 === 0 ? '#f1c40f' : '#e74c3c';
       },
       seatTooltip: (seat) => {
         return 'seat: ' + seat.label ;

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -45,7 +45,7 @@ export default class Floorplan extends React.Component {
 
     // Configure the floorplan
     paper.setup(canvas);
-    this.viewport = new Viewport(paper.view);
+    this.viewport = new Viewport(paper.view, paper.project);
     this.viewport.setZoom(this.props.zoom);
 
     // HARDCODED: center the view for our mocked seats

--- a/src/components/Floorplan.js
+++ b/src/components/Floorplan.js
@@ -1,12 +1,13 @@
 // @flow
 import React from 'react';
-import { paper, Point, Layer } from 'paper';
+import { paper } from 'paper';
 
 import type { SeatsMap } from '../reducers/types';
 import type { SeatData } from '../types';
 
-import { toSeatData } from '../conversions';
 import Seat from './Seat';
+import Viewport from '../viewport';
+import { toSeatData } from '../conversions';
 
 
 type Props = {
@@ -18,25 +19,20 @@ type Props = {
   seatColor: (seat: SeatData) => ?string,
   seatTooltip: (seat: SeatData) => ?string,
 
+  // Redux props
   showTooltip: (text: string ) => void,
   hideTooltip: () => void,
 }
 
+/**
+ * Component rendering a HTML5 Canvas Element containing a Floorplan.
+ */
 export default class Floorplan extends React.Component {
 
   props: Props;
-  view: paper.view;
-  rasterLayer: Layer;
-  seatsLayer: Layer;
+  viewport: Viewport;
 
-  shouldRaster: bool;
   seats: Seat[];
-  update: () => void;
-
-  constructor(props: Props) {
-    super(props);
-    this.update = this.update.bind(this);
-  }
 
   componentDidMount() {
     const canvas = this.refs.canvas;
@@ -47,17 +43,11 @@ export default class Floorplan extends React.Component {
 
     // Configure the floorplan
     paper.setup(canvas);
-    this.view = paper.view;
-    this.view.autoUpdate = false;
-    this.view.zoom = this.props.zoom;
-    this.view.onMouseDrag = (e) => this.onMouseDrag(e);
-    this.view.onMouseUp = (e) => this.onMouseUp(e);
-
-    this.seatsLayer = paper.project.activeLayer;
-    this.rasterLayer = paper.project.addLayer(new Layer());
+    this.viewport = new Viewport(paper.view);
+    this.viewport.setZoom(this.props.zoom);
 
     // HARDCODED: center the view for our mocked seats
-    this.view.center = new Point(1175, 371);
+    this.viewport.setCenter(1175, 371);
 
     // Create and render the seats based on the loaded floorplan.
     this.seats = [];
@@ -80,72 +70,24 @@ export default class Floorplan extends React.Component {
     this.update();
   }
 
-  /**
-   *
-   * Called when the stores the floorplan is subscribed to is updated.
-   */
   componentDidUpdate() {
-    this.view.zoom = this.props.zoom;
     this.update();
   }
 
   /**
-   * Called when the user drags the floorplan around.
+   * Update the floorplan's seat and redraw the viewport.
    */
-  onMouseDrag(e: Object) {
-    const delta = e.delta;
-
-    // reduce drag length
-    delta.length /= 2;
-
-    // inverts the scroll from the drag direction
-    this.view.center = this.view.center.add(new Point(-delta.x, -delta.y));
-
-    // When dragging the floorplan, raster the viewport for insane performances.
-    this.shouldRaster = true;
-
-    this.update();
-  }
-
-  /**
-   * Called when the user is done dragging the floorplan
-   */
-  onMouseUp(e: Object) {
-    this.shouldRaster = false;
-    this.update();
-  }
-
   update() {
-    if (this.shouldRaster) {
-      if(this.rasterLayer.isEmpty())
-        this.rasterLayer.addChild(this.seatsLayer.rasterize());
+    this.viewport.setZoom(this.props.zoom);
 
-      // hide the seats layer and activate the raster layer.
-      this.seatsLayer.visible = false;
-      this.rasterLayer.visible = true;
-    } else {
-      // hide the raster layer and activate the seats layer.
-      this.rasterLayer.visible = false;
-      this.seatsLayer.visible = true;
-
-      this.updateSeats();
-    }
-
-    // reset the raster flag and redraw the floorplan.
-    this.shouldRaster = false;
-    this.view.requestUpdate(this.view.update())
-  }
-
-  /**
-   * Update each seats based on the callback properties of the configuration provided
-   * by the user.
-   */
-  updateSeats() {
+    // Use the user defined callback to modify how each seat's should look like.
     this.seats.forEach((seat) => {
       const seatData = toSeatData(this.props.seats[seat.id]);
-
       seat.color = this.props.seatColor(seatData);
     });
+
+    // finally, redraw the viewport
+    this.viewport.redraw();
   }
 
   render() {

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -71,7 +71,11 @@ export default class Viewport {
    */
   _translate(e: MouseEvent) {
     const delta = e.delta;
-    delta.length /= 2;  // reduce velocity of the drag
+
+    // reduce velocity of the drag
+    // Since it's called multiple time per seconds and we need to divide the lenght of the
+    // delta by 2, use shift operator for sick performances
+    delta.length >>= 1;
 
     this.view.center = this.view.center.add(new Point(-delta.x, -delta.y));
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -63,7 +63,7 @@ export default class Viewport {
       }
 
       this.view.update();
-    })
+    });
   }
 
   /**

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1,12 +1,11 @@
 //@flow
-
 import { View, MouseEvent, Point, Layer } from 'paper';
 
 
 /**
  * Encapsulate the viewport's logic.
- * Expose methods to easily define how the current floorplan should be shown
- * to the user.
+ * Expose an interface to define how the canvas viewed by this viewport instance
+ * should be shown to the user.
  */
 export default class Viewport {
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1,5 +1,5 @@
 //@flow
-import { View, MouseEvent, Point, Layer } from 'paper';
+import { View, MouseEvent, Point, Layer, Project } from 'paper';
 
 
 /**
@@ -15,12 +15,12 @@ export default class Viewport {
   _rasterLayer: Layer;
   _shouldRaster: bool;
 
-  constructor(view: View) {
+  constructor(view: View, project: Project) {
     this.view = view;
     this.view.autoUpdate = false;
 
-    this._mainLayer = view._project.activeLayer;
-    this._rasterLayer = view._project.addLayer(new Layer());
+    this._mainLayer = project.activeLayer;
+    this._rasterLayer = project.addLayer(new Layer());
     this._shouldRaster = false;
 
     this.view.onMouseDrag = (e) => this._translate(e);

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -62,7 +62,7 @@ export default class Viewport {
         this._mainLayer.visible = true;
       }
 
-      this.view.requestUpdate(this.view.update())
+      this.view.update();
     })
   }
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1,0 +1,85 @@
+//@flow
+
+import { View, MouseEvent, Point, Layer } from 'paper';
+
+
+/**
+ * Encapsulate the viewport's logic.
+ * Expose methods to easily define how the current floorplan should be shown
+ * to the user.
+ */
+export default class Viewport {
+
+  view: View;
+
+  _mainLayer: Layer;
+  _rasterLayer: Layer;
+  _shouldRaster: bool;
+
+  constructor(view: View) {
+    this.view = view;
+    this.view.autoUpdate = false;
+
+    this._mainLayer = view._project.activeLayer;
+    this._rasterLayer = view._project.addLayer(new Layer());
+    this._shouldRaster = false;
+
+    this.view.onMouseDrag = (e) => this._translate(e);
+    this.view.onMouseUp = (e) => {
+      this._shouldRaster = false;
+      this.redraw();
+    }
+  }
+
+  /**
+   * Set the viewport's zoom factor.
+   */
+  setZoom(value: number) {
+    this.view.setZoom(value);
+  }
+
+  /**
+   * Set the viewport's center at provided position.
+   */
+  setCenter(x: number, y: number) {
+    this.view.center = new Point(x, y);
+  }
+
+  /**
+   * redraw the viewport's display.
+   */
+  redraw() {
+    requestAnimationFrame(() => {
+      if (this._shouldRaster) {
+        if(this._rasterLayer.isEmpty())
+          this._rasterLayer.addChild(this._mainLayer.rasterize());
+
+        // hide the main layer and activate the raster layer.
+        this._mainLayer.visible = false;
+        this._rasterLayer.visible = true;
+      } else {
+        // hide the raster layer and activate the main layer.
+        this._rasterLayer.visible = false;
+        this._mainLayer.visible = true;
+      }
+
+      this.view.requestUpdate(this.view.update())
+    })
+  }
+
+  /**
+   * Implement how the viewport should translate.
+   */
+  _translate(e: MouseEvent) {
+    const delta = e.delta;
+    delta.length /= 2;  // reduce velocity of the drag
+
+    this.view.center = this.view.center.add(new Point(-delta.x, -delta.y));
+
+    // Raster the main layer when translating the viewport
+    this._shouldRaster = true;
+
+    // redraw the viewport
+    this.redraw();
+  }
+}


### PR DESCRIPTION
This PR adds the Viewport class. The Viewport class encapsulate the logic of the viewport from the Floorplan.

Floorplan component was getting big, now it's small and its only responsible of containing seats.
This also makes the Viewport logic reusable. This is great because we will re-use this logic when writting the Floorplan builder.