### PR TITLE
test for race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,13 @@ floorplanets: .golang-build-image $(FLOORPLANETS_SOURCES) vendor
 gofmt: .golang-build-image
 	$(docker_run_go) bash -c 'go fmt $$(go list ./... | grep -v "/vendor/")'
 
+.PHONY: gotest-race
+gotest-race: FLOORPLANETS_GOTEST_ARGS=-race
+gotest-race: gotest
+
 .PHONY: gotest
 gotest: .golang-build-image vendor
-	$(docker_run_go) bash -c 'go install -v $$(go list ./... | grep -v "/vendor/") && go test -v $$(go list ./... | grep -v "/vendor/")'
+	$(docker_run_go) bash -c 'go install -v $$(go list ./... | grep -v "/vendor/") && go test $(FLOORPLANETS_GOTEST_ARGS) -v $$(go list ./... | grep -v "/vendor/")'
 
 
 #####################
@@ -92,7 +96,7 @@ gotest: .golang-build-image vendor
 #####################
 
 .PHONY: test
-test: gotest nodetest-CI
+test: gotest-race nodetest-CI
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This activates the [golang race detector](https://golang.org/doc/articles/race_detector.html).

Note that

> memory usage may increase by 5-10x and execution time by 2-20x.

For this reason, I am keeping adding a ``gotest-race`` target. Running just ``gotest`` should be more than enough when developing.

Travis will always run the race detector because it uses ``make test``.

It's also reasonable that the race detector be enabled when running ``make test`` because it is usually a target that you run when you are done with a feature. It is not used often. Otherwise, you would be running ``nodetest`` or ``gotest``.

This makes use of [target-specific variables](https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html)